### PR TITLE
Fix go directive syntax in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wercker/stern
 
-go 1.12.9
+go 1.12
 
 require (
 	github.com/fatih/color v0.0.0-20180516100307-2d684516a886


### PR DESCRIPTION
The correct syntax for the go directive in go.mod is go Major.Minor. Violating
this generates an error in recent go versions.